### PR TITLE
feat: Add support for FacilityUse in reference implementation

### DIFF
--- a/.github/workflows/openactive-test-suite.yml
+++ b/.github/workflows/openactive-test-suite.yml
@@ -50,7 +50,7 @@ jobs:
       env:
         FORCE_COLOR: 1
         NODE_CONFIG: |
-          { "outputPath": "../../output/random/", "datasetSiteUrl": "https://localhost:5001/openactive", "sellers": { "primary": { "@type": "Organization", "@id": "https://localhost:5001/api/identifiers/sellers/1", "requestHeaders": { "X-OpenActive-Test-Client-Id": "test", "X-OpenActive-Test-Seller-Id": "https://localhost:5001/api/identifiers/sellers/1" } }, "secondary": { "@type": "Person", "@id": "https://localhost:5001/api/identifiers/sellers/2" } }, "useRandomOpportunities": true, "generateConformanceCertificate": false }
+          { "outputPath": "../../output/random/", "datasetSiteUrl": "https://localhost:5001/openactive", "sellers": { "primary": { "@type": "Organization", "@id": "https://localhost:5001/api/identifiers/sellers/1", "requestHeaders": { "X-OpenActive-Test-Client-Id": "test", "X-OpenActive-Test-Seller-Id": "https://localhost:5001/api/identifiers/sellers/1" } }, "secondary": { "@type": "Organization", "@id": "https://localhost:5001/api/identifiers/sellers/3" } }, "useRandomOpportunities": true, "generateConformanceCertificate": false }
         NODE_ENV: 
       working-directory: tests
     - name: Upload test output for Random Mode as artifact
@@ -68,7 +68,7 @@ jobs:
       env:
         FORCE_COLOR: 1
         NODE_CONFIG: |
-          { "outputPath": "../../output/controlled/", "datasetSiteUrl": "https://localhost:5001/openactive", "sellers": { "primary": { "@type": "Organization", "@id": "https://localhost:5001/api/identifiers/sellers/1", "requestHeaders": { "X-OpenActive-Test-Client-Id": "test", "X-OpenActive-Test-Seller-Id": "https://localhost:5001/api/identifiers/sellers/1" } }, "secondary": { "@type": "Person", "@id": "https://localhost:5001/api/identifiers/sellers/2" } }, "useRandomOpportunities": false, "generateConformanceCertificate": true, "conformanceCertificateId": "https://openactive.io/OpenActive.Server.NET/certification/" }
+          { "outputPath": "../../output/controlled/", "datasetSiteUrl": "https://localhost:5001/openactive", "sellers": { "primary": { "@type": "Organization", "@id": "https://localhost:5001/api/identifiers/sellers/1", "requestHeaders": { "X-OpenActive-Test-Client-Id": "test", "X-OpenActive-Test-Seller-Id": "https://localhost:5001/api/identifiers/sellers/1" } }, "secondary": { "@type": "Organization", "@id": "https://localhost:5001/api/identifiers/sellers/3" } }, "useRandomOpportunities": false, "generateConformanceCertificate": true, "conformanceCertificateId": "https://openactive.io/OpenActive.Server.NET/certification/" }
         NODE_ENV: 
       working-directory: tests
     - name: Upload test output for Controlled Mode as artifact

--- a/Examples/BookingSystem.AspNetCore/Feeds/FacilitiesFeeds.cs
+++ b/Examples/BookingSystem.AspNetCore/Feeds/FacilitiesFeeds.cs
@@ -1,6 +1,9 @@
-﻿using OpenActive.NET;
+﻿using OpenActive.DatasetSite.NET;
+using OpenActive.FakeDatabase.NET;
+using OpenActive.NET;
 using OpenActive.NET.Rpde.Version1;
 using OpenActive.Server.NET.OpenBookingHelper;
+using ServiceStack.OrmLite;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -13,7 +16,74 @@ namespace BookingSystem
 
         protected override List<RpdeItem<FacilityUse>> GetRPDEItems(long? afterTimestamp, long? afterId)
         {
-            throw new OpenBookingException(new NotFoundError());    
+            using (var db = FakeBookingSystem.Database.Mem.Database.Open())
+            {
+                var q = db.From<FacilityUseTable>()
+                .Join<SellerTable>()
+                .OrderBy(x => x.Modified)
+                .ThenBy(x => x.Id)
+                .Where(x => !afterTimestamp.HasValue && !afterId.HasValue ||
+                    x.Modified > afterTimestamp ||
+                    (x.Modified == afterTimestamp && x.Id > afterId) &&
+                    x.Modified < (DateTimeOffset.UtcNow - new TimeSpan(0, 0, 2)).UtcTicks)
+                .Take(this.RPDEPageSize);
+
+                var query = db
+                    .SelectMulti<FacilityUseTable, SellerTable>(q)
+                    .Select((result) => new RpdeItem<FacilityUse>
+                    {
+                        Kind = RpdeKind.FacilityUse,
+                        Id = result.Item1.Id,
+                        Modified = result.Item1.Modified,
+                        State = result.Item1.Deleted ? RpdeState.Deleted : RpdeState.Updated,
+                        Data = result.Item1.Deleted ? null : new FacilityUse
+                        {
+                            // QUESTION: Should the this.IdTemplate and this.BaseUrl be passed in each time rather than set on
+                            // the parent class? Current thinking is it's more extensible on parent class as function signature remains
+                            // constant as power of configuration through underlying class grows (i.e. as new properties are added)
+                            Id = this.RenderOpportunityId(new FacilityOpportunity
+                            {
+                                OpportunityType = OpportunityType.FacilityUse, // isIndividual??
+                                FacilityUseId = result.Item1.Id
+                            }),
+                            Name = result.Item1.Name,
+                            Provider = new Organization
+                            {
+                                Id = this.RenderSellerId(new SellerIdComponents { SellerIdLong = result.Item2.Id }),
+                                Name = result.Item2.Name,
+                                TaxMode = TaxMode.TaxGross
+                            },
+                            Location = new Place
+                            {
+                                Name = "Fake Pond",
+                                Address = new PostalAddress
+                                {
+                                    StreetAddress = "1 Fake Park",
+                                    AddressLocality = "Another town",
+                                    AddressRegion = "Oxfordshire",
+                                    PostalCode = "OX1 1AA",
+                                    AddressCountry = "GB"
+                                },
+                                Geo = new GeoCoordinates
+                                {
+                                    Latitude = 0.1m,
+                                    Longitude = 0.1m
+                                }
+                            },
+                            Url = new Uri("https://www.example.com/a-session-age"),
+                            Activity = new List<Concept> {
+                                new Concept
+                                {
+                                    Id = new Uri("https://openactive.io/activity-list#c07d63a0-8eb9-4602-8bcc-23be6deb8f83"),
+                                    PrefLabel = "Jet Skiing",
+                                    InScheme = new Uri("https://openactive.io/activity-list")
+                                }
+                            }
+                        }
+                    });
+
+                return query.ToList();
+            };
         }
     }
 
@@ -23,9 +93,66 @@ namespace BookingSystem
 
         protected override List<RpdeItem<Slot>> GetRPDEItems(long? afterTimestamp, long? afterId)
         {
-            throw new OpenBookingException(new NotFoundError());
+            using (var db = FakeBookingSystem.Database.Mem.Database.Open())
+            {
+                var query = db.Select<SlotTable>()
+                .OrderBy(x => x.Modified)
+                .ThenBy(x => x.Id)
+                .Where(x => !afterTimestamp.HasValue && !afterId.HasValue ||
+                    x.Modified > afterTimestamp ||
+                    (x.Modified == afterTimestamp && x.Id > afterId) &&
+                    x.Modified < (DateTimeOffset.UtcNow - new TimeSpan(0, 0, 2)).UtcTicks)
+                .Take(this.RPDEPageSize)
+                .Select(x => new RpdeItem<Slot>
+                {
+                    Kind = RpdeKind.FacilityUseSlot,
+                    Id = x.Id,
+                    Modified = x.Modified,
+                    State = x.Deleted ? RpdeState.Deleted : RpdeState.Updated,
+                    Data = x.Deleted ? null : new Slot
+                    {
+                        // QUESTION: Should the this.IdTemplate and this.BaseUrl be passed in each time rather than set on
+                        // the parent class? Current thinking is it's more extensible on parent class as function signature remains
+                        // constant as power of configuration through underlying class grows (i.e. as new properties are added)
+                        Id = this.RenderOpportunityId(new FacilityOpportunity
+                        {
+                            OpportunityType = OpportunityType.FacilityUseSlot,
+                            FacilityUseId = x.FacilityUseId,
+                            SlotId = x.Id
+                        }),
+                        FacilityUse = this.RenderOpportunityId(new FacilityOpportunity
+                        {
+                            OpportunityType = OpportunityType.FacilityUse,
+                            FacilityUseId = x.FacilityUseId
+                        }),
+                        Identifier = x.Id,
+                        StartDate = (DateTimeOffset)x.Start,
+                        EndDate = (DateTimeOffset)x.End,
+                        Duration = x.End - x.Start,
+                        RemainingUses = x.RemainingUses,
+                        MaximumUses = x.MaximumUses,
+                        Offers = new List<Offer> { new Offer
+                                {
+                                    Id = this.RenderOfferId(new FacilityOpportunity
+                                    {
+                                        OfferId = 0,
+                                        FacilityUseId = x.FacilityUseId,
+                                        OpportunityType = OpportunityType.FacilityUseSlot,
+                                        SlotId = x.Id
+                                    }),
+                                    Price = new Decimal(11.1),
+                                    PriceCurrency = "GBP",
+                                    AvailableChannel = new List<AvailableChannelType>
+                                    {
+                                        AvailableChannelType.OpenBookingPrepayment
+                                    }
+                                }
+                            },
+                    }
+                });
+
+                return query.ToList();
+            }
         }
     }
-
-
 }

--- a/Examples/BookingSystem.AspNetCore/Feeds/FacilitiesFeeds.cs
+++ b/Examples/BookingSystem.AspNetCore/Feeds/FacilitiesFeeds.cs
@@ -95,25 +95,21 @@ namespace BookingSystem
         {
             using (var db = FakeBookingSystem.Database.Mem.Database.Open())
             {
-                var q = db.From<SlotTable>()
-                .Join<FacilityUseTable>()
+                var query = db.Select<SlotTable>()
                 .OrderBy(x => x.Modified)
                 .ThenBy(x => x.Id)
                 .Where(x => !afterTimestamp.HasValue && !afterId.HasValue ||
                     x.Modified > afterTimestamp ||
                     (x.Modified == afterTimestamp && x.Id > afterId) &&
                     x.Modified < (DateTimeOffset.UtcNow - new TimeSpan(0, 0, 2)).UtcTicks)
-                .Take(this.RPDEPageSize);
-
-
-                var query = db.SelectMulti<SlotTable, FacilityUseTable>(q)
-                .Select(result => new RpdeItem<Slot>
+                .Take(this.RPDEPageSize)
+                .Select(x => new RpdeItem<Slot>
                 {
                     Kind = RpdeKind.FacilityUseSlot,
-                    Id = result.Item1.Id,
-                    Modified = result.Item1.Modified,
-                    State = result.Item1.Deleted ? RpdeState.Deleted : RpdeState.Updated,
-                    Data = result.Item1.Deleted ? null : new Slot
+                    Id = x.Id,
+                    Modified = x.Modified,
+                    State = x.Deleted ? RpdeState.Deleted : RpdeState.Updated,
+                    Data = x.Deleted ? null : new Slot
                     {
                         // QUESTION: Should the this.IdTemplate and this.BaseUrl be passed in each time rather than set on
                         // the parent class? Current thinking is it's more extensible on parent class as function signature remains
@@ -121,30 +117,30 @@ namespace BookingSystem
                         Id = this.RenderOpportunityId(new FacilityOpportunity
                         {
                             OpportunityType = OpportunityType.FacilityUseSlot,
-                            FacilityUseId = result.Item1.FacilityUseId,
-                            SlotId = result.Item1.Id
+                            FacilityUseId = x.FacilityUseId,
+                            SlotId = x.Id
                         }),
                         FacilityUse = this.RenderOpportunityId(new FacilityOpportunity
                         {
                             OpportunityType = OpportunityType.FacilityUse,
-                            FacilityUseId = result.Item1.FacilityUseId
+                            FacilityUseId = x.FacilityUseId
                         }),
-                        Identifier = result.Item1.Id,
-                        StartDate = (DateTimeOffset)result.Item1.Start,
-                        EndDate = (DateTimeOffset)result.Item1.End,
-                        Duration = result.Item1.End - result.Item1.Start,
-                        RemainingUses = result.Item1.RemainingUses,
-                        MaximumUses = result.Item1.MaximumUses,
+                        Identifier = x.Id,
+                        StartDate = (DateTimeOffset)x.Start,
+                        EndDate = (DateTimeOffset)x.End,
+                        Duration = x.End - x.Start,
+                        RemainingUses = x.RemainingUses,
+                        MaximumUses = x.MaximumUses,
                         Offers = new List<Offer> { new Offer
                                 {
                                     Id = this.RenderOfferId(new FacilityOpportunity
                                     {
                                         OfferId = 0,
-                                        FacilityUseId = result.Item1.FacilityUseId,
                                         OpportunityType = OpportunityType.FacilityUseSlot,
-                                        SlotId = result.Item1.Id
+                                        FacilityUseId = x.FacilityUseId,
+                                        SlotId = x.Id
                                     }),
-                                    Price = result.Item2.Price,
+                                    Price = x.Price,
                                     PriceCurrency = "GBP",
                                     AvailableChannel = new List<AvailableChannelType>
                                     {

--- a/Examples/BookingSystem.AspNetCore/IdComponents/FacilityOpportunity.cs
+++ b/Examples/BookingSystem.AspNetCore/IdComponents/FacilityOpportunity.cs
@@ -14,7 +14,7 @@ namespace BookingSystem
     public class FacilityOpportunity : IBookableIdComponents
     {
         public OpportunityType? OpportunityType { get; set; }
-        public string FacilityUseId { get; set; }
+        public long? FacilityUseId { get; set; }
         public long? SlotId { get; set; }
         public long? OfferId { get; set; }
 

--- a/Examples/BookingSystem.AspNetCore/Settings/EngineConfig.cs
+++ b/Examples/BookingSystem.AspNetCore/Settings/EngineConfig.cs
@@ -35,7 +35,7 @@ namespace BookingSystem
                                 OpportunityIdTemplate = "{+BaseUrl}session-series/{SessionSeriesId}",
                                 OfferIdTemplate =       "{+BaseUrl}session-series/{SessionSeriesId}#/offers/{OfferId}",
                                 Bookable = false
-                            }), 
+                            }),
 
                         new BookablePairIdTemplate<FacilityOpportunity> (
                             // Opportunity
@@ -108,7 +108,7 @@ namespace BookingSystem
 
                     JsonLdIdBaseUrl = new Uri(baseUrl + "api/identifiers/"),
 
-                
+
                     // Multiple Seller Mode
                     SellerStore = new AcmeSellerStore(),
                     SellerIdTemplate = new SingleIdTemplate<SellerIdComponents>(
@@ -177,7 +177,8 @@ namespace BookingSystem
                     // A list of the supported fields that are accepted by your system for guest checkout bookings
                     // These are reflected back to the broker
                     // Note that only E-mail address is required, as per Open Booking API spec
-                    CustomerPersonSupportedFields = p => new Person {
+                    CustomerPersonSupportedFields = p => new Person
+                    {
                         Email = p.Email,
                         GivenName = p.GivenName,
                         FamilyName = p.FamilyName,
@@ -186,7 +187,8 @@ namespace BookingSystem
                     // A list of the supported fields that are accepted by your system for guest checkout bookings
                     // These are reflected back to the broker
                     // Note that only E-mail address is required, as per Open Booking API spec
-                    CustomerOrganizationSupportedFields = o => new Organization {
+                    CustomerOrganizationSupportedFields = o => new Organization
+                    {
                         Email = o.Email,
                         Name = o.Name,
                         Telephone = o.Telephone
@@ -194,7 +196,8 @@ namespace BookingSystem
                     // A list of the supported fields that are accepted by your system for broker details
                     // These are reflected back to the broker
                     // Note that storage of these details is entirely optional
-                    BrokerSupportedFields = o => new Organization {
+                    BrokerSupportedFields = o => new Organization
+                    {
                         Name = o.Name,
                         Url = o.Url,
                         Telephone = o.Telephone
@@ -227,6 +230,9 @@ namespace BookingSystem
                     OpportunityStoreRouting = new Dictionary<IOpportunityStore, List<OpportunityType>> {
                         {
                             new SessionStore(), new List<OpportunityType> { OpportunityType.ScheduledSession }
+                        },
+                        {
+                            new FacilityStore(), new List<OpportunityType> { OpportunityType.FacilityUseSlot }
                         }
                     },
                     OrderStore = new AcmeOrderStore(),

--- a/Examples/BookingSystem.AspNetCore/Stores/FacilityStore.cs
+++ b/Examples/BookingSystem.AspNetCore/Stores/FacilityStore.cs
@@ -100,7 +100,7 @@ namespace BookingSystem
                                         new TaxChargeSpecification
                                         {
                                             Name = "VAT at 20%",
-                                            Price = facility.Price * (decimal?)0.2,
+                                            Price = slot.Price * (decimal?)0.2,
                                             PriceCurrency = "GBP",
                                             Rate = (decimal?)0.2
                                         }
@@ -109,7 +109,7 @@ namespace BookingSystem
                                  {
                                      // Note this should always use RenderOfferId with the supplied SessioFacilityOpportunitynOpportunity, to take into account inheritance and OfferType
                                      Id = this.RenderOfferId(orderItemContext.RequestBookableOpportunityOfferId),
-                                     Price = facility.Price,
+                                     Price = slot.Price,
                                      PriceCurrency = "GBP"
                                  },
                                  OrderedItem = new Slot

--- a/Examples/BookingSystem.AspNetCore/Stores/FacilityStore.cs
+++ b/Examples/BookingSystem.AspNetCore/Stores/FacilityStore.cs
@@ -1,0 +1,256 @@
+﻿using OpenActive.NET;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenActive.DatasetSite.NET;
+using OpenActive.Server.NET.StoreBooking;
+using OpenActive.Server.NET.OpenBookingHelper;
+using OpenActive.FakeDatabase.NET;
+using ServiceStack.OrmLite;
+
+namespace BookingSystem
+{
+    class FacilityStore : OpportunityStore<FacilityOpportunity, OrderTransaction, OrderStateContext>
+    {
+
+        protected override FacilityOpportunity CreateOpportunityWithinTestDataset(string testDatasetIdentifier, OpportunityType opportunityType, TestOpportunityCriteriaEnumeration criteria, SellerIdComponents seller)
+        {
+            switch (opportunityType)
+            {
+                case OpportunityType.FacilityUseSlot:
+                    switch (criteria)
+                    {
+                        case TestOpportunityCriteriaEnumeration.TestOpportunityBookableCancellable:
+                        case TestOpportunityCriteriaEnumeration.TestOpportunityBookablePaid:
+                        case TestOpportunityCriteriaEnumeration.TestOpportunityBookable:
+                            var (facilityId1, slotId1) = FakeBookingSystem.Database.AddFacility(testDatasetIdentifier, seller.SellerIdLong.Value, "[OPEN BOOKING API TEST INTERFACE] Bookable Paid Event", 14.99M, DateTimeOffset.Now.AddDays(1), DateTimeOffset.Now.AddDays(1).AddHours(1), 10);
+                            return new FacilityOpportunity
+                            {
+                                OpportunityType = opportunityType,
+                                FacilityUseId = facilityId1,
+                                SlotId = slotId1
+                            };
+                        case TestOpportunityCriteriaEnumeration.TestOpportunityBookableFree:
+                            var (facilityId2, slotId2) = FakeBookingSystem.Database.AddFacility(testDatasetIdentifier, seller.SellerIdLong.Value, "[OPEN BOOKING API TEST INTERFACE] Bookable Free Event", 0M, DateTimeOffset.Now.AddDays(1), DateTimeOffset.Now.AddDays(1).AddHours(1), 10);
+                            return new FacilityOpportunity
+                            {
+                                OpportunityType = opportunityType,
+                                FacilityUseId = facilityId2,
+                                SlotId = slotId2
+                            };
+                        case TestOpportunityCriteriaEnumeration.TestOpportunityBookableNoSpaces:
+                            var (facilityId3, slotId3) = FakeBookingSystem.Database.AddFacility(testDatasetIdentifier, seller.SellerIdLong.Value, "[OPEN BOOKING API TEST INTERFACE] Bookable Free Event", 14.99M, DateTimeOffset.Now.AddDays(1), DateTimeOffset.Now.AddDays(1).AddHours(1), 0);
+                            return new FacilityOpportunity
+                            {
+                                OpportunityType = opportunityType,
+                                FacilityUseId = facilityId3,
+                                SlotId = slotId3
+                            };
+                        default:
+                            throw new OpenBookingException(new OpenBookingError(), "testOpportunityCriteria value not supported");
+                    }
+
+
+                default:
+                    throw new OpenBookingException(new OpenBookingError(), "Opportunity Type not supported");
+            }
+        }
+
+        protected override void DeleteTestDataset(string testDatasetIdentifier)
+        {
+            FakeBookingSystem.Database.DeleteTestFacilitiesFromDataset(testDatasetIdentifier);
+        }
+
+        protected override void TriggerTestAction(OpenBookingSimulateAction simulateAction, FacilityOpportunity idComponents)
+        {
+            throw new NotImplementedException();
+        }
+
+
+        // Similar to the RPDE logic, this needs to render and return an new hypothetical OrderItem from the database based on the supplied opportunity IDs
+        protected override void GetOrderItems(List<OrderItemContext<FacilityOpportunity>> orderItemContexts, StoreBookingFlowContext flowContext, OrderStateContext stateContext)
+        {
+
+            // Note the implementation of this method must also check that this OrderItem is from the Seller specified by context.SellerIdComponents (this is not required if using a Single Seller)
+
+            // Additionally this method must check that there are enough spaces in each entry
+
+            // Response OrderItems must be updated into supplied orderItemContexts (including duplicates for multi-party booking)
+
+            List<SlotTable> slotTable;
+            List<FacilityUseTable> facilityTable;
+            using (var db = FakeBookingSystem.Database.Mem.Database.Open())
+            {
+                slotTable = db.Select<SlotTable>();
+                facilityTable = db.Select<FacilityUseTable>();
+            }
+           
+            var query = (from orderItemContext in orderItemContexts
+                         join slot in slotTable on orderItemContext.RequestBookableOpportunityOfferId.SlotId equals slot.Id
+                         join facility in facilityTable on slot.FacilityUseId equals facility.Id
+                         // and offers.id = opportunityOfferId.OfferId
+                         select slot == null ? null : new {
+                             OrderItem = new OrderItem
+                             {
+                                 AllowCustomerCancellationFullRefund = true,
+                                 // TODO: The static example below should come from the database (which doesn't currently support tax)
+                                 UnitTaxSpecification = flowContext.TaxPayeeRelationship == TaxPayeeRelationship.BusinessToConsumer ?
+                                     new List<TaxChargeSpecification>
+                                     {
+                                        new TaxChargeSpecification
+                                        {
+                                            Name = "VAT at 20%",
+                                            Price = facility.Price * (decimal?)0.2,
+                                            PriceCurrency = "GBP",
+                                            Rate = (decimal?)0.2
+                                        }
+                                     } : null,
+                                 AcceptedOffer = new Offer
+                                 {
+                                     // Note this should always use RenderOfferId with the supplied SessioFacilityOpportunitynOpportunity, to take into account inheritance and OfferType
+                                     Id = this.RenderOfferId(orderItemContext.RequestBookableOpportunityOfferId),
+                                     Price = facility.Price,
+                                     PriceCurrency = "GBP"
+                                 },
+                                 OrderedItem = new Slot
+                                 {
+                                     // Note this should always be driven from the database, with new FacilityOpportunity's instantiated
+                                     Id = this.RenderOpportunityId(new FacilityOpportunity
+                                     {
+                                         OpportunityType = OpportunityType.FacilityUseSlot,
+                                         FacilityUseId = slot.FacilityUseId,
+                                         SlotId = slot.Id
+                                     }),
+                                     FacilityUse = new FacilityUse
+                                     {
+                                         Id = this.RenderOpportunityId(new FacilityOpportunity
+                                         {
+                                             OpportunityType = OpportunityType.FacilityUse,
+                                             FacilityUseId = slot.FacilityUseId
+                                         }),
+                                         Name = facility.Name,
+                                         Url = new Uri("https://example.com/events/" + slot.FacilityUseId),
+                                         Location = new Place
+                                         {
+                                             Name = "Fake fitness studio",
+                                             Geo = new GeoCoordinates
+                                             {
+                                                 Latitude = 51.6201M,
+                                                 Longitude = 0.302396M
+                                             }
+                                         },
+                                         Activity = new List<Concept>
+                                         {
+                                             new Concept
+                                             {
+                                                 Id = new Uri("https://openactive.io/activity-list#6bdea630-ad22-4e58-98a3-bca26ee3f1da"),
+                                                 PrefLabel = "Rave Fitness",
+                                                 InScheme = new Uri("https://openactive.io/activity-list")
+                                             }
+                                         }
+                                     },
+                                     StartDate = (DateTimeOffset)slot.Start,
+                                     EndDate = (DateTimeOffset)slot.End,
+                                     MaximumAttendeeCapacity = slot.MaximumUses,
+                                     RemainingAttendeeCapacity = slot.RemainingUses
+                                 }
+                             },
+                             SellerId = new SellerIdComponents { SellerIdLong = facility.SellerId }
+                           });
+
+            // Add the response OrderItems to the relevant contexts (note that the context must be updated within this method)
+            foreach (var (item, ctx) in query.Zip(orderItemContexts, (item, ctx) => (item, ctx)))
+            {
+                if (item == null)
+                {
+                    ctx.SetResponseOrderItemAsSkeleton();
+                    ctx.AddError(new UnknownOpportunityError());
+                }
+                else
+                {
+                    ctx.SetResponseOrderItem(item.OrderItem, item.SellerId, flowContext);
+
+                    if (item.OrderItem.OrderedItem.RemainingAttendeeCapacity == 0)
+                    {
+                        ctx.AddError(new OpportunityIsFullError());
+                    }
+                }
+                
+            }
+
+            // Add errors to the response according to the attendee details specified as required in the ResponseOrderItem,
+            // and those provided in the requestOrderItem
+            orderItemContexts.ForEach(ctx => ctx.ValidateAttendeeDetails());
+
+            // Additional attendee detail validation logic goes here
+            // ...
+
+        }
+
+        protected override void LeaseOrderItems(Lease lease, List<OrderItemContext<FacilityOpportunity>> orderItemContexts, StoreBookingFlowContext flowContext, OrderStateContext stateContext, OrderTransaction databaseTransaction)
+        {
+            // Check that there are no conflicts between the supplied opportunities
+            // Also take into account spaces requested across OrderItems against total spaces in each opportunity
+
+            foreach (var ctxGroup in orderItemContexts.GroupBy(x => x.RequestBookableOpportunityOfferId))
+            {
+                // Check that the Opportunity ID and type are as expected for the store 
+                if (ctxGroup.Key.OpportunityType != OpportunityType.FacilityUseSlot || !ctxGroup.Key.SlotId.HasValue)
+                {
+                    foreach (var ctx in ctxGroup)
+                    {
+                        ctx.AddError(new OpportunityIntractableError(), "Opportunity ID and type are as not expected for the store. Likely a configuration issue with the Booking System.");
+                    }
+                }
+                else
+                {
+                    // Attempt to lease for those with the same IDs, which is atomic
+                    bool result = databaseTransaction.Database.LeaseOrderItemsForFacilitySlot(flowContext.OrderId.ClientId, flowContext.SellerId.SellerIdLong ?? null /* Hack to allow this to work in Single Seller mode too */, flowContext.OrderId.uuid, ctxGroup.Key.SlotId.Value, ctxGroup.Count());
+
+                    if (!result)
+                    {
+                        foreach (var ctx in ctxGroup)
+                        {
+                            ctx.AddError(new OpportunityIntractableError(), "OrderItem could not be leased for unexpected reasons.");
+                        }
+                    }
+                }
+            }
+        }
+
+        //TODO: This should reuse code of LeaseOrderItem
+        protected override void BookOrderItems(List<OrderItemContext<FacilityOpportunity>> orderItemContexts, StoreBookingFlowContext flowContext, OrderStateContext stateContext, OrderTransaction databaseTransaction)
+        {
+            // Check that there are no conflicts between the supplied opportunities
+            // Also take into account spaces requested across OrderItems against total spaces in each opportunity
+
+            foreach (var ctxGroup in orderItemContexts.GroupBy(x => x.RequestBookableOpportunityOfferId))
+            {
+                // Check that the Opportunity ID and type are as expected for the store 
+                if (ctxGroup.Key.OpportunityType != OpportunityType.FacilityUseSlot || !ctxGroup.Key.SlotId.HasValue)
+                {
+                    throw new OpenBookingException(new UnableToProcessOrderItemError());
+                }
+
+                // Attempt to book for those with the same IDs, which is atomic
+                List<long> orderItemIds = databaseTransaction.Database.BookOrderItemsForFacilitySlot(flowContext.OrderId.ClientId, flowContext.SellerId.SellerIdLong ?? null  /* Hack to allow this to work in Single Seller mode too */, flowContext.OrderId.uuid, ctxGroup.Key.SlotId.Value, this.RenderOpportunityJsonLdType(ctxGroup.Key), this.RenderOpportunityId(ctxGroup.Key).ToString(), this.RenderOfferId(ctxGroup.Key).ToString(), ctxGroup.Count());
+
+                if (orderItemIds != null)
+                {
+                    // Set OrderItemId for each orderItemContext
+                    foreach (var (ctx, id) in ctxGroup.Zip(orderItemIds, (ctx, id) => (ctx, id)))
+                    {
+                        ctx.SetOrderItemId(flowContext, id);
+                    }
+                }
+                else
+                {
+                    // Note: A real implementation would not through an error this vague
+                    throw new OpenBookingException(new OrderCreationFailedError(), "Booking failed for an unexpected reason");
+                }
+            }
+        }
+
+    }
+
+}

--- a/Examples/BookingSystem.AspNetCore/Stores/FacilityStore.cs
+++ b/Examples/BookingSystem.AspNetCore/Stores/FacilityStore.cs
@@ -84,7 +84,7 @@ namespace BookingSystem
                 slotTable = db.Select<SlotTable>();
                 facilityTable = db.Select<FacilityUseTable>();
             }
-           
+
             var query = (from orderItemContext in orderItemContexts
                          join slot in slotTable on orderItemContext.RequestBookableOpportunityOfferId.SlotId equals slot.Id
                          join facility in facilityTable on slot.FacilityUseId equals facility.Id
@@ -151,8 +151,8 @@ namespace BookingSystem
                                      },
                                      StartDate = (DateTimeOffset)slot.Start,
                                      EndDate = (DateTimeOffset)slot.End,
-                                     MaximumAttendeeCapacity = slot.MaximumUses,
-                                     RemainingAttendeeCapacity = slot.RemainingUses
+                                     MaximumUses = slot.MaximumUses,
+                                     RemainingUses= slot.RemainingUses
                                  }
                              },
                              SellerId = new SellerIdComponents { SellerIdLong = facility.SellerId }
@@ -170,7 +170,7 @@ namespace BookingSystem
                 {
                     ctx.SetResponseOrderItem(item.OrderItem, item.SellerId, flowContext);
 
-                    if (item.OrderItem.OrderedItem.RemainingAttendeeCapacity == 0)
+                    if (((Slot)item.OrderItem.OrderedItem).RemainingUses == 0)
                     {
                         ctx.AddError(new OpportunityIsFullError());
                     }

--- a/Fakes/OpenActive.FakeDatabase.NET/DatabaseTables.cs
+++ b/Fakes/OpenActive.FakeDatabase.NET/DatabaseTables.cs
@@ -66,6 +66,11 @@ namespace OpenActive.FakeDatabase.NET
         public OccurrenceTable OccurrenceTable { get; set; }
         [ForeignKey(typeof(OccurrenceTable), OnDelete = "CASCADE")]
         public long OccurrenceId { get; set; }
+        [Reference]
+        public SlotTable SlotTable { get; set; }
+        [ForeignKey(typeof(SlotTable), OnDelete = "CASCADE")]
+        public long SlotId { get; set; }
+
         public BookingStatus Status { get; set; }
         public decimal Price { get; set; }
     }
@@ -95,6 +100,33 @@ namespace OpenActive.FakeDatabase.NET
         public bool IsIndividual { get; set; }
     }
 
+    public class SlotTable : Table
+    {
+        public string TestDatasetIdentifier { get; set; }
+        [Reference]
+        public FacilityUseTable FacilityUseTable { get; set; }
+        [ForeignKey(typeof(FacilityUseTable), OnDelete = "CASCADE")]
+        public long FacilityUseId { get; set; }
+        public DateTime Start { get; set; }
+        public DateTime End { get; set; }
+        public long MaximumUses { get; set; }
+        public long LeasedUses { get; set; }
+
+        public long RemainingUses { get; set; }
+    }
+
+    public class FacilityUseTable : Table
+    {
+        public string TestDatasetIdentifier { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        [Reference]
+        public SellerTable SellerTable { get; set; }
+        [ForeignKey(typeof(SellerTable), OnDelete = "CASCADE")]
+        public long SellerId { get; set; } // Provider
+        public decimal? Price { get; set; }
+    }
+
     public static class DatabaseCreator
     {
         public static void CreateTables(OrmLiteConnectionFactory dbFactory)
@@ -106,11 +138,15 @@ namespace OpenActive.FakeDatabase.NET
                 db.DropTable<OrderTable>();
                 db.DropTable<ClassTable>();
                 db.DropTable<SellerTable>();
+                db.DropTable<FacilityUseTable>();
+                db.DropTable<SlotTable>();
                 db.CreateTable<SellerTable>();
                 db.CreateTable<ClassTable>();
                 db.CreateTable<OrderTable>();
                 db.CreateTable<OccurrenceTable>();
                 db.CreateTable<OrderItemsTable>();
+                db.CreateTable<FacilityUseTable>();
+                db.CreateTable<SlotTable>();
             }
         }
     }

--- a/Fakes/OpenActive.FakeDatabase.NET/DatabaseTables.cs
+++ b/Fakes/OpenActive.FakeDatabase.NET/DatabaseTables.cs
@@ -111,8 +111,8 @@ namespace OpenActive.FakeDatabase.NET
         public DateTime End { get; set; }
         public long MaximumUses { get; set; }
         public long LeasedUses { get; set; }
-
         public long RemainingUses { get; set; }
+        public decimal? Price { get; set; }
     }
 
     public class FacilityUseTable : Table
@@ -124,7 +124,6 @@ namespace OpenActive.FakeDatabase.NET
         public SellerTable SellerTable { get; set; }
         [ForeignKey(typeof(SellerTable), OnDelete = "CASCADE")]
         public long SellerId { get; set; } // Provider
-        public decimal? Price { get; set; }
     }
 
     public static class DatabaseCreator

--- a/Fakes/OpenActive.FakeDatabase.NET/FakeBookingSystem.cs
+++ b/Fakes/OpenActive.FakeDatabase.NET/FakeBookingSystem.cs
@@ -643,7 +643,8 @@ namespace OpenActive.FakeDatabase.NET
 
             var sellers = new List<SellerTable> {
                 new SellerTable { Id = 1, Name = "Acme Fitness Ltd", IsIndividual = false },
-                new SellerTable { Id = 2, Name = "Jane Smith", IsIndividual = false }
+                new SellerTable { Id = 2, Name = "Jane Smith", IsIndividual = true },
+                new SellerTable { Id = 3, Name = "Lorem Fitsum Ltd", IsIndividual = false }
             };
 
             using (var db = Mem.Database.Open())

--- a/Fakes/OpenActive.FakeDatabase.NET/FakeBookingSystem.cs
+++ b/Fakes/OpenActive.FakeDatabase.NET/FakeBookingSystem.cs
@@ -601,7 +601,7 @@ namespace OpenActive.FakeDatabase.NET
                     Id = id,
                     Deleted = false,
                     Name = faker.Commerce.ProductMaterial() + " " + faker.PickRandomParam("Sports Hall", "Swimming Pool Hall", "Running Hall", "Jumping Hall"),
-                    SellerId = 1
+                    SellerId = faker.Random.Bool() ? 1 : 3
                 })
                 .ToList();
 
@@ -637,7 +637,7 @@ namespace OpenActive.FakeDatabase.NET
                 Deleted = false,
                 Title = faker.Commerce.ProductMaterial() + " " + faker.PickRandomParam("Yoga", "Zumba", "Walking", "Cycling", "Running", "Jumping"),
                 Price = Decimal.Parse(faker.Random.Bool() ? "0.00" : faker.Commerce.Price(0, 20)),
-                SellerId = faker.Random.Long(1, 2)
+                SellerId = faker.Random.Long(1, 3)
             })
             .ToList();
 

--- a/Fakes/OpenActive.FakeDatabase.NET/FakeBookingSystem.cs
+++ b/Fakes/OpenActive.FakeDatabase.NET/FakeBookingSystem.cs
@@ -444,7 +444,7 @@ namespace OpenActive.FakeDatabase.NET
                                 OpportunityJsonLdId = opportunityJsonLdId,
                                 OfferJsonLdId = offerJsonLdId,
                                 // Include the price locked into the OrderItem as the opportunity price may change
-                                Price = thisFacility.Price.Value
+                                Price = thisSlot.Price.Value
                             }, true);
                             OrderItemIds.Add(orderItemId);
                         }
@@ -590,7 +590,8 @@ namespace OpenActive.FakeDatabase.NET
                     Start = x.StartDate,
                     End = x.StartDate + TimeSpan.FromMinutes(faker.Random.Int(30, 360)),
                     MaximumUses = x.TotalUses,
-                    RemainingUses = x.TotalUses
+                    RemainingUses = x.TotalUses,
+                    Price = Decimal.Parse(faker.Random.Bool() ? "0.00" : faker.Commerce.Price(0, 20)),
                 })
                 .ToList();
 
@@ -600,7 +601,6 @@ namespace OpenActive.FakeDatabase.NET
                     Id = id,
                     Deleted = false,
                     Name = faker.Commerce.ProductMaterial() + " " + faker.PickRandomParam("Sports Hall", "Swimming Pool Hall", "Running Hall", "Jumping Hall"),
-                    Price = Decimal.Parse(faker.Random.Bool() ? "0.00" : faker.Commerce.Price(0, 20)),
                     SellerId = faker.Random.Long(1, 2)
                 })
                 .ToList();
@@ -643,7 +643,7 @@ namespace OpenActive.FakeDatabase.NET
 
             var sellers = new List<SellerTable> {
                 new SellerTable { Id = 1, Name = "Acme Fitness Ltd", IsIndividual = false },
-                new SellerTable { Id = 2, Name = "Jane Smith", IsIndividual = true }
+                new SellerTable { Id = 2, Name = "Jane Smith", IsIndividual = false }
             };
 
             using (var db = Mem.Database.Open())
@@ -691,7 +691,6 @@ namespace OpenActive.FakeDatabase.NET
                     TestDatasetIdentifier = testDatasetIdentifier,
                     Deleted = false,
                     Name = title,
-                    Price = price,
                     SellerId = seller
                 }, true);
 
@@ -703,7 +702,8 @@ namespace OpenActive.FakeDatabase.NET
                     Start = startTime.DateTime,
                     End = endTime.DateTime,
                     MaximumUses = totalUses,
-                    RemainingUses = totalUses
+                    RemainingUses = totalUses,
+                    Price = price
                 }, true);
 
                 return ((int)facilityId, (int)slotId);

--- a/Fakes/OpenActive.FakeDatabase.NET/FakeBookingSystem.cs
+++ b/Fakes/OpenActive.FakeDatabase.NET/FakeBookingSystem.cs
@@ -601,7 +601,7 @@ namespace OpenActive.FakeDatabase.NET
                     Id = id,
                     Deleted = false,
                     Name = faker.Commerce.ProductMaterial() + " " + faker.PickRandomParam("Sports Hall", "Swimming Pool Hall", "Running Hall", "Jumping Hall"),
-                    SellerId = faker.Random.Long(1, 2)
+                    SellerId = 1
                 })
                 .ToList();
 

--- a/OpenActive.Server.NET/CustomBookingEngine/CustomBookingEngine.cs
+++ b/OpenActive.Server.NET/CustomBookingEngine/CustomBookingEngine.cs
@@ -409,7 +409,7 @@ namespace OpenActive.Server.NET.CustomBooking
 
         ResponseContent IBookingEngine.InsertTestOpportunity(string testDatasetIdentifier, string eventJson)
         {
-            Event genericEvent = OpenActiveSerializer.Deserialize<ScheduledSession>(eventJson);
+            Event genericEvent = OpenActiveSerializer.Deserialize<Event>(eventJson);
 
             // Note opportunityType is required here to facilitate routing to the correct store to handle the request
             OpportunityType? opportunityType = null;


### PR DESCRIPTION
- Added facility and slot feeds (FacilitiesFeeds.cs)
- Added FacilityStore (similar to SessionStore) and added it EngineConfig for OpportunityStoreRouting
- Added new tables to DatabaseTables.cs (for Slot and FacilityUse) and extended some of the existing (OrderItemsTable)
- Added necessary operations for Facility and Slot with tables created above in FakeBookingSystem.cs (similar as for Session, this could probably be refactored a bit as there is some duplicated code there)