### PR TITLE
- added support for IncompleteOrderItemError

### DIFF
--- a/OpenActive.Server.NET/CustomBookingEngine/CustomBookingEngine.cs
+++ b/OpenActive.Server.NET/CustomBookingEngine/CustomBookingEngine.cs
@@ -296,6 +296,11 @@ namespace OpenActive.Server.NET.CustomBooking
             return this.idConfigurationLookup.ContainsKey(opportunityTypeString);
         }
 
+        protected IBookablePairIdTemplate GetComponentsWhenNoOpportunityOrOffer(string opportunityTypeString)
+        {
+            return this.idConfigurationLookup[opportunityTypeString].FirstOrDefault();
+        }
+
         // Note this is not a helper as it relies on engine settings state
         protected IBookableIdComponents ResolveOpportunityID(string opportunityTypeString, Uri opportunityId, Uri offerId)
         {

--- a/OpenActive.Server.NET/CustomBookingEngine/CustomBookingEngine.cs
+++ b/OpenActive.Server.NET/CustomBookingEngine/CustomBookingEngine.cs
@@ -296,11 +296,6 @@ namespace OpenActive.Server.NET.CustomBooking
             return this.idConfigurationLookup.ContainsKey(opportunityTypeString);
         }
 
-        protected IBookablePairIdTemplate GetComponentsWhenNoOpportunityOrOffer(string opportunityTypeString)
-        {
-            return this.idConfigurationLookup[opportunityTypeString].FirstOrDefault();
-        }
-
         // Note this is not a helper as it relies on engine settings state
         protected IBookableIdComponents ResolveOpportunityID(string opportunityTypeString, Uri opportunityId, Uri offerId)
         {

--- a/OpenActive.Server.NET/StoreBookingEngine/StoreBookingEngine.cs
+++ b/OpenActive.Server.NET/StoreBookingEngine/StoreBookingEngine.cs
@@ -467,6 +467,12 @@ namespace OpenActive.Server.NET.StoreBooking
                 throw new OpenBookingException(new IncompleteBrokerDetailsError());
             }
 
+            // Throw error on Incomplete Order Item Error if OrderedItem or AcceptedOffer is null or their Urls don't match.
+            if ((context.Stage == FlowStage.C1 || context.Stage == FlowStage.C2 || context.Stage == FlowStage.B) && order.OrderedItem.Any(orderItem => orderItem.OrderedItem == null || orderItem.AcceptedOffer == null || orderItem.OrderedItem.Url != orderItem.AcceptedOffer.Url))
+            {
+                throw new OpenBookingException(new IncompleteOrderItemError());
+            }
+
             // Reflect back only those broker fields that are supported
             context.Broker = storeBookingEngineSettings.BrokerSupportedFields(order.Broker);
 
@@ -507,7 +513,6 @@ namespace OpenActive.Server.NET.StoreBooking
 
             // Add totals to the resulting Order
             OrderCalculations.AugmentOrderWithTotals(responseGenericOrder);
-
 
             switch (responseGenericOrder)
             {

--- a/OpenActive.Server.NET/StoreBookingEngine/StoreBookingEngine.cs
+++ b/OpenActive.Server.NET/StoreBookingEngine/StoreBookingEngine.cs
@@ -182,7 +182,7 @@ namespace OpenActive.Server.NET.StoreBooking
         private readonly List<IOpportunityStore> stores;
         private readonly Dictionary<OpportunityType, IOpportunityStore> storeRouting;
         private readonly StoreBookingEngineSettings storeBookingEngineSettings;
-        
+
         protected override Event InsertTestOpportunity(string testDatasetIdentifier, OpportunityType opportunityType, TestOpportunityCriteriaEnumeration criteria, SellerIdComponents seller)
         {
             if (!storeRouting.ContainsKey(opportunityType))
@@ -193,7 +193,7 @@ namespace OpenActive.Server.NET.StoreBooking
 
         protected override void DeleteTestDataset(string testDatasetIdentifier)
         {
-            foreach(var store in storeRouting.Values)
+            foreach (var store in storeRouting.Values)
             {
                 store.DeleteTestDataset(testDatasetIdentifier);
             }
@@ -356,7 +356,8 @@ namespace OpenActive.Server.NET.StoreBooking
         private (List<IOrderItemContext>, List<OrderItemContextGroup>) GetOrderItemContexts(List<OrderItem> sourceOrderItems, StoreBookingFlowContext flowContext, IStateContext stateContext)
         {
             // Create OrderItemContext for each OrderItem
-            var orderItemContexts = sourceOrderItems.Select((orderItem, index) => {
+            var orderItemContexts = sourceOrderItems.Select((orderItem, index) =>
+            {
                 // Error if this group of types is not recognised
                 if (!base.IsOpportunityTypeRecognised(orderItem.OrderedItem.Type))
                 {
@@ -466,12 +467,12 @@ namespace OpenActive.Server.NET.StoreBooking
                 throw new OpenBookingException(new IncompleteBrokerDetailsError());
             }
 
-<<<<<<< HEAD
             // Throw error on Incomplete Order Item Error if OrderedItem or AcceptedOffer is null or their Urls don't match.
             if ((context.Stage == FlowStage.C1 || context.Stage == FlowStage.C2 || context.Stage == FlowStage.B) && order.OrderedItem.Any(orderItem => orderItem.OrderedItem == null || orderItem.AcceptedOffer == null || orderItem.OrderedItem.Url != orderItem.AcceptedOffer.Url))
             {
                 throw new OpenBookingException(new IncompleteOrderItemError());
-=======
+            }
+
             // Throw error on incomplete customer details if C2, P or B if Broker type is not ResellerBroker
             if (order.BrokerRole != BrokerType.ResellerBroker)
             {
@@ -479,7 +480,6 @@ namespace OpenActive.Server.NET.StoreBooking
                 {
                     throw new OpenBookingException(new IncompleteCustomerDetailsError());
                 }
->>>>>>> master
             }
 
             // Reflect back only those broker fields that are supported
@@ -521,12 +521,8 @@ namespace OpenActive.Server.NET.StoreBooking
             };
 
             // Add totals to the resulting Order
-<<<<<<< HEAD
-            OrderCalculations.AugmentOrderWithTotals(responseGenericOrder);
-=======
             OrderCalculations.AugmentOrderWithTotals(
                 responseGenericOrder, context, storeBookingEngineSettings.BusinessToConsumerTaxCalculation, storeBookingEngineSettings.BusinessToBusinessTaxCalculation);
->>>>>>> master
 
             switch (responseGenericOrder)
             {
@@ -573,7 +569,7 @@ namespace OpenActive.Server.NET.StoreBooking
                             responseOrderProposal.OrderedItem = orderItemContexts.Select(x => x.ResponseOrderItem).ToList();
 
                             storeBookingEngineSettings.OrderStore.UpdateOrderProposal(responseOrderProposal, context, stateContext, dbTransaction);
-                            
+
                             dbTransaction.Commit();
                         }
                         catch
@@ -598,34 +594,34 @@ namespace OpenActive.Server.NET.StoreBooking
                     // Leasing is optimistic, booking is atomic
                     using (IDatabaseTransaction dbTransaction = storeBookingEngineSettings.OrderStore.BeginOrderTransaction(context.Stage))
                     {
-                            try
-                            {
-                                responseOrderQuote.Lease = storeBookingEngineSettings.OrderStore.CreateLease(responseOrderQuote, context, stateContext, dbTransaction);
+                        try
+                        {
+                            responseOrderQuote.Lease = storeBookingEngineSettings.OrderStore.CreateLease(responseOrderQuote, context, stateContext, dbTransaction);
 
-                                // Lease the OrderItems, if a lease exists
-                                if (responseOrderQuote.Lease != null)
+                            // Lease the OrderItems, if a lease exists
+                            if (responseOrderQuote.Lease != null)
+                            {
+                                foreach (var g in orderItemGroups)
                                 {
-                                    foreach (var g in orderItemGroups)
-                                    {
-                                        g.Store.LeaseOrderItems(responseOrderQuote.Lease, g.OrderItemContexts, context, stateContext, dbTransaction);
-                                    }
+                                    g.Store.LeaseOrderItems(responseOrderQuote.Lease, g.OrderItemContexts, context, stateContext, dbTransaction);
                                 }
-
-                                // Update this in case ResponseOrderItem was overwritten in Lease
-                                responseOrderQuote.OrderedItem = orderItemContexts.Select(x => x.ResponseOrderItem).ToList();
-
-                                // Note OrderRequiresApproval is only required during C1 and C2
-                                responseOrderQuote.OrderRequiresApproval = orderItemContexts.Any(x => x.RequiresApproval);
-
-                                storeBookingEngineSettings.OrderStore.UpdateLease(responseOrderQuote, context, stateContext, dbTransaction);
-
-                                if (dbTransaction != null) dbTransaction.Commit();
                             }
-                            catch
-                            {
-                                if (dbTransaction != null) dbTransaction.Rollback();
-                                throw;
-                            }
+
+                            // Update this in case ResponseOrderItem was overwritten in Lease
+                            responseOrderQuote.OrderedItem = orderItemContexts.Select(x => x.ResponseOrderItem).ToList();
+
+                            // Note OrderRequiresApproval is only required during C1 and C2
+                            responseOrderQuote.OrderRequiresApproval = orderItemContexts.Any(x => x.RequiresApproval);
+
+                            storeBookingEngineSettings.OrderStore.UpdateLease(responseOrderQuote, context, stateContext, dbTransaction);
+
+                            if (dbTransaction != null) dbTransaction.Commit();
+                        }
+                        catch
+                        {
+                            if (dbTransaction != null) dbTransaction.Rollback();
+                            throw;
+                        }
                     }
                     break;
 
@@ -647,7 +643,7 @@ namespace OpenActive.Server.NET.StoreBooking
                         {
                             // Create the parent Order
                             storeBookingEngineSettings.OrderStore.CreateOrder(responseOrder, context, stateContext, dbTransaction);
-                            
+
                             // Book the OrderItems
                             foreach (var g in orderItemGroups)
                             {
@@ -656,7 +652,7 @@ namespace OpenActive.Server.NET.StoreBooking
                                 foreach (var ctx in g.OrderItemContexts)
                                 {
                                     // Check that OrderItem Id was added
-                                    if (ctx.ResponseOrderItemId == null || ctx.ResponseOrderItem.Id == null )
+                                    if (ctx.ResponseOrderItemId == null || ctx.ResponseOrderItem.Id == null)
                                     {
                                         throw new ArgumentException("SetOrderItemId must be called for each OrderItemContext in BookOrderItems");
                                     }

--- a/OpenActive.Server.NET/StoreBookingEngine/StoreBookingEngine.cs
+++ b/OpenActive.Server.NET/StoreBookingEngine/StoreBookingEngine.cs
@@ -159,7 +159,6 @@ namespace OpenActive.Server.NET.StoreBooking
             if (datasetSettings == null) throw new ArgumentNullException(nameof(datasetSettings));
             if (storeBookingEngineSettings == null) throw new ArgumentNullException(nameof(storeBookingEngineSettings));
 
-            this.stores = storeBookingEngineSettings.OpportunityStoreRouting.Keys.ToList();
             this.storeBookingEngineSettings = storeBookingEngineSettings;
 
             // TODO: Add test to ensure there are not two or more at FirstOrDefault step, in case of configuration error 
@@ -179,7 +178,6 @@ namespace OpenActive.Server.NET.StoreBooking
             storeBookingEngineSettings.OrderStore.SetConfiguration(settings.OrderIdTemplate, settings.SellerIdTemplate);
         }
 
-        private readonly List<IOpportunityStore> stores;
         private readonly Dictionary<OpportunityType, IOpportunityStore> storeRouting;
         private readonly StoreBookingEngineSettings storeBookingEngineSettings;
 
@@ -363,6 +361,16 @@ namespace OpenActive.Server.NET.StoreBooking
                 {
                     return new UnknownOrderItemContext(index, orderItem,
                         new UnknownOpportunityError(), $"The type of opportunity specified is not recognised: '{orderItem.OrderedItem.Type}'.");
+                }
+
+                if (orderItem.OrderedItem.Id == null)
+                {
+                    var a = GetComponentsWhenNoOpportunityOrOffer(orderItem.OrderedItem.Type);
+                    Type typea = typeof(OrderItemContext<>).MakeGenericType(a.GetType());
+
+                    OrderItemContext<> orderItemContexta = (IOrderItemContext)Activator.CreateInstance(typea);
+                    orderItemContexta.Index = index;
+                    // orderItemContexta.
                 }
 
                 var idComponents = base.ResolveOpportunityID(orderItem.OrderedItem.Type, orderItem.OrderedItem.Id, orderItem.AcceptedOffer.Id);

--- a/OpenActive.Server.NET/StoreBookingEngine/StoreBookingEngine.cs
+++ b/OpenActive.Server.NET/StoreBookingEngine/StoreBookingEngine.cs
@@ -1,10 +1,8 @@
 ﻿using System.Collections.Generic;
 using System;
 using System.Linq;
-using System.Text;
 using OpenActive.DatasetSite.NET;
 using OpenActive.NET;
-using OpenActive.NET.Rpde.Version1;
 using OpenActive.Server.NET.OpenBookingHelper;
 using OpenActive.Server.NET.CustomBooking;
 
@@ -361,16 +359,6 @@ namespace OpenActive.Server.NET.StoreBooking
                 {
                     return new UnknownOrderItemContext(index, orderItem,
                         new UnknownOpportunityError(), $"The type of opportunity specified is not recognised: '{orderItem.OrderedItem.Type}'.");
-                }
-
-                if (orderItem.OrderedItem.Id == null)
-                {
-                    var a = GetComponentsWhenNoOpportunityOrOffer(orderItem.OrderedItem.Type);
-                    Type typea = typeof(OrderItemContext<>).MakeGenericType(a.GetType());
-
-                    OrderItemContext<> orderItemContexta = (IOrderItemContext)Activator.CreateInstance(typea);
-                    orderItemContexta.Index = index;
-                    // orderItemContexta.
                 }
 
                 var idComponents = base.ResolveOpportunityID(orderItem.OrderedItem.Type, orderItem.OrderedItem.Id, orderItem.AcceptedOffer.Id);


### PR DESCRIPTION
@nickevansuk copying whot I wrote you so you get reminder when you start looking at this:

In StoreBookingEngine.cs this is the chain of calling which will lead to exception, (even if it is not nullpointer it will be ArgumentNullException)
ProcessFlowRequest -> GetOrderItemContexts -> ResolveOpportunityID -> GetOpportunityReference which will throw ArgumentNullException for either one of them.
Meaning we won't get to CheckOrderIntegrity.

So only place that I found that it is applicable to do it is in AugmentContextFromOrder where we can throw the error, but it is not going to be in error property?
it is going to result in same response for c1 c2 as for b:
{
  "@context": "https://openactive.io/",
  "@type": "IncompleteOrderItemError",
  "name": "There is a missing 'acceptedOffer' or 'orderedItem' property on the 'OrderItem'.",
  "statusCode": 409
}
but I don't think this is valid response type for C1 and C2?

 you can use that check to put it in right place for C1 and C2