### PR TITLE
Add idempotency protection to B

### DIFF
--- a/Examples/BookingSystem.AspNetCore/Stores/OrderStore.cs
+++ b/Examples/BookingSystem.AspNetCore/Stores/OrderStore.cs
@@ -254,7 +254,7 @@ namespace BookingSystem
                 );
         }
 
-        public async override ValueTask CreateOrder(Order responseOrder, StoreBookingFlowContext flowContext, OrderStateContext stateContext, OrderTransaction databaseTransaction)
+        public async override ValueTask<CreateOrderResult> CreateOrder(Order responseOrder, StoreBookingFlowContext flowContext, OrderStateContext stateContext, OrderTransaction databaseTransaction)
         {
             if (_appSettings.FeatureFlags.PaymentReconciliationDetailValidation && responseOrder.TotalPaymentDue.Price > 0 && ReconciliationMismatch(flowContext))
                 throw new OpenBookingException(new InvalidPaymentDetailsError(), "Payment reconciliation details do not match");
@@ -287,7 +287,9 @@ namespace BookingSystem
                 null,
                 null);
 
-            if (!result) throw new OpenBookingException(new OrderAlreadyExistsError());
+            if (!result) return CreateOrderResult.OrderAlreadyExists;
+
+            return CreateOrderResult.OrderSuccessfullyCreated;
         }
 
         public async override ValueTask UpdateOrder(Order responseOrder, StoreBookingFlowContext flowContext, OrderStateContext stateContext, OrderTransaction databaseTransaction)

--- a/Examples/BookingSystem.AspNetFramework/Stores/OrderStore.cs
+++ b/Examples/BookingSystem.AspNetFramework/Stores/OrderStore.cs
@@ -254,7 +254,7 @@ namespace BookingSystem
                 );
         }
 
-        public async override ValueTask CreateOrder(Order responseOrder, StoreBookingFlowContext flowContext, OrderStateContext stateContext, OrderTransaction databaseTransaction)
+        public async override ValueTask<CreateOrderResult> CreateOrder(Order responseOrder, StoreBookingFlowContext flowContext, OrderStateContext stateContext, OrderTransaction databaseTransaction)
         {
             if (_appSettings.FeatureFlags.PaymentReconciliationDetailValidation && responseOrder.TotalPaymentDue.Price > 0 && ReconciliationMismatch(flowContext))
                 throw new OpenBookingException(new InvalidPaymentDetailsError(), "Payment reconciliation details do not match");
@@ -287,7 +287,9 @@ namespace BookingSystem
                 null,
                 null);
 
-            if (!result) throw new OpenBookingException(new OrderAlreadyExistsError());
+            if (!result) return CreateOrderResult.OrderAlreadyExists;
+
+            return CreateOrderResult.OrderSuccessfullyCreated;
         }
 
         public async override ValueTask UpdateOrder(Order responseOrder, StoreBookingFlowContext flowContext, OrderStateContext stateContext, OrderTransaction databaseTransaction)

--- a/OpenActive.Server.NET/StoreBookingEngine/StoreBookingEngine.cs
+++ b/OpenActive.Server.NET/StoreBookingEngine/StoreBookingEngine.cs
@@ -723,7 +723,7 @@ namespace OpenActive.Server.NET.StoreBooking
                         {
                             // Create the parent Order
                             if (storeBookingEngineSettings.EnforceSyncWithinOrderTransactions)
-                                storeBookingEngineSettings.OrderStore.CreateOrder(responseOrder, context, stateContext, dbTransaction).CheckSyncValueTaskWorked();
+                                storeBookingEngineSettings.OrderStore.CreateOrder(responseOrder, context, stateContext, dbTransaction).CheckSyncValueTaskWorkedAndReturnResult();
                             else
                                 await storeBookingEngineSettings.OrderStore.CreateOrder(responseOrder, context, stateContext, dbTransaction);
 

--- a/OpenActive.Server.NET/StoreBookingEngine/Stores/OrderStore.cs
+++ b/OpenActive.Server.NET/StoreBookingEngine/Stores/OrderStore.cs
@@ -51,6 +51,7 @@ namespace OpenActive.Server.NET.StoreBooking
         ValueTask UpdateOrder(Order responseOrder, StoreBookingFlowContext flowContext, IStateContext stateContext, IDatabaseTransaction dbTransaction);
         ValueTask<(Guid, OrderProposalStatus)> CreateOrderProposal(OrderProposal responseOrderProposal, StoreBookingFlowContext flowContext, IStateContext stateContext, IDatabaseTransaction dbTransaction);
         ValueTask UpdateOrderProposal(OrderProposal responseOrderProposal, StoreBookingFlowContext flowContext, IStateContext stateContext, IDatabaseTransaction dbTransaction);
+        ValueTask<string> GetIdempotentOrderResponse(OrderIdComponents orderId, string requestHash);
     }
 
     public interface IStateContext
@@ -111,6 +112,11 @@ namespace OpenActive.Server.NET.StoreBooking
         public ValueTask UpdateOrderProposal(OrderProposal responseOrderProposal, StoreBookingFlowContext flowContext, IStateContext stateContext, IDatabaseTransaction dbTransaction)
         {
             return UpdateOrderProposal(responseOrderProposal, flowContext, (TStateContext)stateContext, (TDatabaseTransaction)dbTransaction);
+        }
+
+        public async virtual ValueTask<string> GetIdempotentOrderResponse(OrderIdComponents orderIdComponents, string requestHash)
+        {
+            return "";
         }
     }
 }

--- a/OpenActive.Server.NET/StoreBookingEngine/Stores/OrderStore.cs
+++ b/OpenActive.Server.NET/StoreBookingEngine/Stores/OrderStore.cs
@@ -52,6 +52,7 @@ namespace OpenActive.Server.NET.StoreBooking
         ValueTask<(Guid, OrderProposalStatus)> CreateOrderProposal(OrderProposal responseOrderProposal, StoreBookingFlowContext flowContext, IStateContext stateContext, IDatabaseTransaction dbTransaction);
         ValueTask UpdateOrderProposal(OrderProposal responseOrderProposal, StoreBookingFlowContext flowContext, IStateContext stateContext, IDatabaseTransaction dbTransaction);
         ValueTask<string> GetIdempotentOrderResponse(OrderIdComponents orderId, string requestHash);
+        ValueTask CompleteOrder(Order responseOrder, StoreBookingFlowContext flowContext, IStateContext stateContext, IDatabaseTransaction dbTransaction, string serialisedResponseOrder, string requestHash);
     }
 
     public interface IStateContext
@@ -117,6 +118,10 @@ namespace OpenActive.Server.NET.StoreBooking
         public async virtual ValueTask<string> GetIdempotentOrderResponse(OrderIdComponents orderIdComponents, string requestHash)
         {
             return "";
+        }
+
+        public async ValueTask CompleteOrder(Order responseOrder, StoreBookingFlowContext flowContext, IStateContext stateContext, IDatabaseTransaction dbTransaction, string serialisedResponseOrder, string requestHash)
+        {
         }
     }
 }

--- a/OpenActive.Server.NET/StoreBookingEngine/Stores/OrderStore.cs
+++ b/OpenActive.Server.NET/StoreBookingEngine/Stores/OrderStore.cs
@@ -16,6 +16,15 @@ namespace OpenActive.Server.NET.StoreBooking
         OrderDidNotExist
     }
 
+    /// <summary>
+    /// Result of creating (or attempting to create) an Order in a store
+    /// </summary>
+    public enum CreateOrderResult
+    {
+        OrderSuccessfullyCreated,
+        OrderAlreadyExists
+    }
+
     public interface IOrderStore
     {
         void SetConfiguration(OrderIdTemplate orderIdTemplate, SingleIdTemplate<SellerIdComponents> sellerIdTemplate);
@@ -38,7 +47,7 @@ namespace OpenActive.Server.NET.StoreBooking
 
         ValueTask<Lease> CreateLease(OrderQuote responseOrderQuote, StoreBookingFlowContext flowContext, IStateContext stateContext, IDatabaseTransaction dbTransaction);
         ValueTask UpdateLease(OrderQuote responseOrderQuote, StoreBookingFlowContext flowContext, IStateContext stateContext, IDatabaseTransaction dbTransaction);
-        ValueTask CreateOrder(Order responseOrder, StoreBookingFlowContext flowContext, IStateContext stateContext, IDatabaseTransaction dbTransaction);
+        ValueTask<CreateOrderResult> CreateOrder(Order responseOrder, StoreBookingFlowContext flowContext, IStateContext stateContext, IDatabaseTransaction dbTransaction);
         ValueTask UpdateOrder(Order responseOrder, StoreBookingFlowContext flowContext, IStateContext stateContext, IDatabaseTransaction dbTransaction);
         ValueTask<(Guid, OrderProposalStatus)> CreateOrderProposal(OrderProposal responseOrderProposal, StoreBookingFlowContext flowContext, IStateContext stateContext, IDatabaseTransaction dbTransaction);
         ValueTask UpdateOrderProposal(OrderProposal responseOrderProposal, StoreBookingFlowContext flowContext, IStateContext stateContext, IDatabaseTransaction dbTransaction);
@@ -80,8 +89,8 @@ namespace OpenActive.Server.NET.StoreBooking
             return UpdateLease(responseOrderQuote, flowContext, (TStateContext)stateContext, (TDatabaseTransaction)dbTransaction);
         }
 
-        public abstract ValueTask CreateOrder(Order responseOrder, StoreBookingFlowContext flowContext, TStateContext stateContext, TDatabaseTransaction dbTransaction);
-        public ValueTask CreateOrder(Order responseOrder, StoreBookingFlowContext flowContext, IStateContext stateContext, IDatabaseTransaction dbTransaction)
+        public abstract ValueTask<CreateOrderResult> CreateOrder(Order responseOrder, StoreBookingFlowContext flowContext, TStateContext stateContext, TDatabaseTransaction dbTransaction);
+        public ValueTask<CreateOrderResult> CreateOrder(Order responseOrder, StoreBookingFlowContext flowContext, IStateContext stateContext, IDatabaseTransaction dbTransaction)
         {
             return CreateOrder(responseOrder, flowContext, (TStateContext)stateContext, (TDatabaseTransaction)dbTransaction);
         }


### PR DESCRIPTION
When finished, should fix #100 

Currently draft format.  Per the comment [here](https://github.com/openactive/OpenActive.Server.NET/issues/100#issuecomment-855725000), I have attempted to change the return type of ProcessFlowResult.  Could not just return a string, as `ProcessCheckpoint` uses the orderQuote to determine the HttpStatusCode to return, so added a `ProcessFlowResult` object to contain both the string to return and this value.

I'm not sure about this though, design-wise, as it is adding an Http dependency to the CustomBookingEngine which may violate some design principles here, so throwing this up as a draft for review.