### PR TITLE
Add parallel request protection for Order B

### DIFF
--- a/OpenActive.Server.NET/CustomBookingEngine/CustomBookingEngine.cs
+++ b/OpenActive.Server.NET/CustomBookingEngine/CustomBookingEngine.cs
@@ -377,7 +377,7 @@ namespace OpenActive.Server.NET.CustomBooking
         }
         private async Task<ResponseContent> ProcessCheckpoint(string clientId, Uri sellerId, string uuid, string orderQuoteJson, FlowStage flowStage, OrderType orderType)
         {
-            using ( await asyncDuplicateLock.LockAsync( GetParallelLockKey(clientId, uuid) ) )
+            using (await asyncDuplicateLock.LockAsync(GetParallelLockKey(clientId, uuid)))
             {
                 OrderQuote orderQuote = OpenActiveSerializer.Deserialize<OrderQuote>(orderQuoteJson);
                 if (orderQuote == null || orderQuote.GetType() != typeof(OrderQuote))
@@ -393,7 +393,7 @@ namespace OpenActive.Server.NET.CustomBooking
         }
         public async Task<ResponseContent> ProcessOrderCreationB(string clientId, Uri sellerId, string uuid, string orderJson)
         {
-            using ( await asyncDuplicateLock.LockAsync( GetParallelLockKey(clientId, uuid) ) )
+            using (await asyncDuplicateLock.LockAsync(GetParallelLockKey(clientId, uuid)))
             {
                 // Note B will never contain OrderItem level errors, and any issues that occur will be thrown as exceptions.
                 // If C1 and C2 are used correctly, B should not fail except in very exceptional cases.
@@ -417,7 +417,7 @@ namespace OpenActive.Server.NET.CustomBooking
 
         public async Task<ResponseContent> ProcessOrderProposalCreationP(string clientId, Uri sellerId, string uuid, string orderJson)
         {
-            using ( await asyncDuplicateLock.LockAsync( GetParallelLockKey(clientId, uuid) ) )
+            using (await asyncDuplicateLock.LockAsync(GetParallelLockKey(clientId, uuid)))
             {
                 // Note B will never contain OrderItem level errors, and any issues that occur will be thrown as exceptions.
                 // If C1 and C2 are used correctly, P should not fail except in very exceptional cases.
@@ -443,7 +443,7 @@ namespace OpenActive.Server.NET.CustomBooking
 
         public async Task<ResponseContent> DeleteOrder(string clientId, Uri sellerId, string uuid)
         {
-            using ( await asyncDuplicateLock.LockAsync( GetParallelLockKey(clientId, uuid) ) )
+            using (await asyncDuplicateLock.LockAsync(GetParallelLockKey(clientId, uuid)))
             {
                 var result = await ProcessOrderDeletion(new OrderIdComponents { ClientId = clientId, OrderType = OrderType.Order, uuid = uuid }, GetSellerIdComponentsFromApiKey(sellerId));
                 switch (result)
@@ -462,7 +462,7 @@ namespace OpenActive.Server.NET.CustomBooking
 
         public async Task<ResponseContent> DeleteOrderQuote(string clientId, Uri sellerId, string uuid)
         {
-            using ( await asyncDuplicateLock.LockAsync( GetParallelLockKey(clientId, uuid) ) )
+            using (await asyncDuplicateLock.LockAsync(GetParallelLockKey(clientId, uuid)))
             {
                 await ProcessOrderQuoteDeletion(new OrderIdComponents { ClientId = clientId, OrderType = OrderType.OrderQuote, uuid = uuid }, GetSellerIdComponentsFromApiKey(sellerId));
                 return ResponseContent.OpenBookingNoContentResponse();
@@ -473,7 +473,7 @@ namespace OpenActive.Server.NET.CustomBooking
 
         public async Task<ResponseContent> ProcessOrderUpdate(string clientId, Uri sellerId, string uuid, string orderJson)
         {
-            using ( await asyncDuplicateLock.LockAsync( GetParallelLockKey(clientId, uuid) ) )
+            using (await asyncDuplicateLock.LockAsync(GetParallelLockKey(clientId, uuid)))
             {
                 Order order = OpenActiveSerializer.Deserialize<Order>(orderJson);
                 SellerIdComponents sellerIdComponents = GetSellerIdComponentsFromApiKey(sellerId);
@@ -524,7 +524,7 @@ namespace OpenActive.Server.NET.CustomBooking
 
         public async Task<ResponseContent> ProcessOrderProposalUpdate(string clientId, Uri sellerId, string uuid, string orderProposalJson)
         {
-            using ( await asyncDuplicateLock.LockAsync( GetParallelLockKey(clientId, uuid) ) )
+            using (await asyncDuplicateLock.LockAsync(GetParallelLockKey(clientId, uuid)))
             {
                 OrderProposal orderProposal = OpenActiveSerializer.Deserialize<OrderProposal>(orderProposalJson);
                 SellerIdComponents sellerIdComponents = GetSellerIdComponentsFromApiKey(sellerId);
@@ -562,7 +562,7 @@ namespace OpenActive.Server.NET.CustomBooking
 
         async Task<ResponseContent> IBookingEngine.InsertTestOpportunity(string testDatasetIdentifier, string eventJson)
         {
-            using ( await asyncDuplicateLock.LockAsync( testDatasetIdentifier.ToLower() ) )
+            using (await asyncDuplicateLock.LockAsync(testDatasetIdentifier.ToLower()))
             {
                 Event genericEvent = OpenActiveSerializer.Deserialize<Event>(eventJson);
 

--- a/OpenActive.Server.NET/CustomBookingEngine/CustomBookingEngine.cs
+++ b/OpenActive.Server.NET/CustomBookingEngine/CustomBookingEngine.cs
@@ -130,7 +130,7 @@ namespace OpenActive.Server.NET.CustomBooking
         private Uri openDataFeedBaseUrl;
         private Dictionary<string, List<IBookablePairIdTemplate>> idConfigurationLookup;
         private Dictionary<OpportunityType, IBookablePairIdTemplate> feedAssignedTemplates;
-        private readonly AsyncDuplicateLock asyncDuplicateLock = new AsyncDuplicateLock();
+        private readonly AsyncDuplicateLock<string> asyncDuplicateLock = new AsyncDuplicateLock<string>();
         protected Dictionary<OpportunityType, IBookablePairIdTemplate> OpportunityTemplateLookup { get; }
 
         /// <summary>

--- a/OpenActive.Server.NET/OpenBookingHelper/Async/AsyncDuplicateLock.cs
+++ b/OpenActive.Server.NET/OpenBookingHelper/Async/AsyncDuplicateLock.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OpenActive.Server.NET.OpenBookingHelper.Async
+{
+    public sealed class AsyncDuplicateLock
+    {
+        private sealed class RefCounted<T>
+        {
+            public RefCounted(T value)
+            {
+                RefCount = 1;
+                Value = value;
+            }
+
+            public int RefCount { get; set; }
+            public T Value { get; }
+        }
+
+        private static readonly Dictionary<object, RefCounted<SemaphoreSlim>> SemaphoreSlims
+            = new Dictionary<object, RefCounted<SemaphoreSlim>>();
+
+        private SemaphoreSlim GetOrCreate(object key)
+        {
+            RefCounted<SemaphoreSlim> item;
+            lock (SemaphoreSlims)
+            {
+                if (SemaphoreSlims.TryGetValue(key, out item))
+                {
+                    ++item.RefCount;
+                }
+                else
+                {
+                    item = new RefCounted<SemaphoreSlim>(new SemaphoreSlim(1, 1));
+                    SemaphoreSlims[key] = item;
+                }
+            }
+            return item.Value;
+        }
+
+        public async Task<IDisposable> LockAsync(object key)
+        {
+            await GetOrCreate(key).WaitAsync().ConfigureAwait(false);
+            return new Releaser { Key = key };
+        }
+
+        private sealed class Releaser : IDisposable
+        {
+            public object Key { get; set; }
+
+            public void Dispose()
+            {
+                RefCounted<SemaphoreSlim> item;
+                lock (SemaphoreSlims)
+                {
+                    item = SemaphoreSlims[Key];
+                    --item.RefCount;
+                    if (item.RefCount == 0)
+                        SemaphoreSlims.Remove(Key);
+                }
+                item.Value.Release();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Related to #100 

Adds AsyncDuplicateLock, which was copied from Steven Cleary's [answer ](https://stackoverflow.com/a/31194647/448129) to this [SO question](https://stackoverflow.com/questions/31138179/asynchronous-locking-based-on-a-key).  We've used this for years to prevent the same situation in callbacks from POS webhooks or Payment Gateway callbacks, so confident in its functionality.  Though, I appreciate, there are no tests here...