### PR TITLE
feat: RPDE cache headers

### DIFF
--- a/Examples/BookingSystem.AspNetCore/Helpers/ResponseContentHelper.cs
+++ b/Examples/BookingSystem.AspNetCore/Helpers/ResponseContentHelper.cs
@@ -1,15 +1,46 @@
-﻿namespace BookingSystem.AspNetCore.Helpers
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BookingSystem.AspNetCore.Helpers
 {
     public static class ResponseContentHelper
     {
         public static Microsoft.AspNetCore.Mvc.ContentResult GetContentResult(this OpenActive.Server.NET.OpenBookingHelper.ResponseContent response)
         {
-            return new Microsoft.AspNetCore.Mvc.ContentResult
+            return new CacheableContentResult
             {
                 StatusCode = (int)response.StatusCode,
                 Content = response.Content,
-                ContentType = response.ContentType
+                ContentType = response.ContentType,
+                CacheControlMaxAge = response.CacheControlMaxAge,
             };
+        }
+    }
+
+    /// <summary>
+    /// ContentResult that also sets Cache-Control: public, max-age=X, s-maxage=X
+    /// See https://developer.openactive.io/publishing-data/data-feeds/scaling-feeds for more information
+    /// </summary>
+    public class CacheableContentResult : Microsoft.AspNetCore.Mvc.ContentResult
+    {
+        public TimeSpan CacheControlMaxAge { get; set; }
+
+        public override async Task ExecuteResultAsync(ActionContext context)
+        {
+            if (CacheControlMaxAge != null)
+            {
+                context.HttpContext.Response.GetTypedHeaders().CacheControl =
+                    new Microsoft.Net.Http.Headers.CacheControlHeaderValue()
+                    {
+                        Public = true,
+                        MaxAge = CacheControlMaxAge,
+                        SharedMaxAge = CacheControlMaxAge,
+                    };
+            }
+
+            await base.ExecuteResultAsync(context);
         }
     }
 }

--- a/Examples/BookingSystem.AspNetFramework/Helpers/ResponseContentHelper.cs
+++ b/Examples/BookingSystem.AspNetFramework/Helpers/ResponseContentHelper.cs
@@ -14,6 +14,17 @@ namespace BookingSystem.AspNetFramework.Helpers
                 StatusCode = response.StatusCode
             };
             resp.Content.Headers.ContentType = MediaTypeHeaderValue.Parse(response.ContentType);
+            /// Sets additional header Cache-Control: public, max-age=X, s-maxage=X
+            /// See https://developer.openactive.io/publishing-data/data-feeds/scaling-feeds for more information
+            if (response.CacheControlMaxAge != null)
+            {
+                resp.Headers.CacheControl = new CacheControlHeaderValue()
+                {
+                    Public = true,
+                    MaxAge = response.CacheControlMaxAge,
+                    SharedMaxAge = response.CacheControlMaxAge
+                };
+            }
             // Ensure custom error messages do not override responses
             HttpContext.Current.Response.TrySkipIisCustomErrors = true;
             return resp;

--- a/OpenActive.Server.NET/CustomBookingEngine/CustomBookingEngine.cs
+++ b/OpenActive.Server.NET/CustomBookingEngine/CustomBookingEngine.cs
@@ -169,15 +169,14 @@ namespace OpenActive.Server.NET.CustomBooking
         /// <returns></returns>
         public async Task<ResponseContent> GetOpenDataRPDEPageForFeed(string feedname, string afterTimestamp, string afterId, string afterChangeNumber)
         {
-            return ResponseContent.RpdeResponse(
+            return GetResponseContentFromRPDEPage(
                 (await RouteOpenDataRPDEPageForFeed(
                     feedname,
                     RpdeOrderingStrategyRouter.ConvertStringToLongOrThrow(afterTimestamp, nameof(afterTimestamp)),
                     afterId,
                     RpdeOrderingStrategyRouter.ConvertStringToLongOrThrow(afterChangeNumber, nameof(afterChangeNumber))
-                    )).ToString());
+                    )));
         }
-
 
         /// <summary>
         /// Handler for an RPDE endpoint
@@ -191,11 +190,14 @@ namespace OpenActive.Server.NET.CustomBooking
         /// <returns></returns>
         public async Task<ResponseContent> GetOpenDataRPDEPageForFeed(string feedname, long? afterTimestamp, string afterId, long? afterChangeNumber)
         {
-            return ResponseContent.RpdeResponse((await RouteOpenDataRPDEPageForFeed(feedname, afterTimestamp, afterId, afterChangeNumber)).ToString());
+            return GetResponseContentFromRPDEPage(await RouteOpenDataRPDEPageForFeed(feedname, afterTimestamp, afterId, afterChangeNumber));
         }
 
-
-
+        private ResponseContent GetResponseContentFromRPDEPage(RpdePage rpdePage)
+        {
+            var cacheMaxAge = rpdePage.Items.Count == 0 ? this.settings.RPDELastPageCacheDuration : this.settings.RPDEPageCacheDuration;
+            return ResponseContent.RpdeResponse(rpdePage.ToString(), cacheMaxAge);
+        }
 
         /// <summary>
         /// Handler for an RPDE endpoint

--- a/OpenActive.Server.NET/OpenBookingHelper/Content/ResponseContent.cs
+++ b/OpenActive.Server.NET/OpenBookingHelper/Content/ResponseContent.cs
@@ -1,4 +1,5 @@
 ﻿using OpenActive.NET;
+using System;
 using System.Net;
 
 namespace OpenActive.Server.NET.OpenBookingHelper
@@ -60,13 +61,14 @@ namespace OpenActive.Server.NET.OpenBookingHelper
             };
         }
 
-        public static ResponseContent RpdeResponse(string content)
+        public static ResponseContent RpdeResponse(string content, TimeSpan cacheControlMaxAge)
         {
             return new ResponseContent
             {
                 Content = content,
                 ContentType = OpenActiveMediaTypes.RealtimePagedDataExchange.Version1,
-                StatusCode = HttpStatusCode.OK
+                StatusCode = HttpStatusCode.OK,
+                CacheControlMaxAge = cacheControlMaxAge
             };
         }
 
@@ -82,6 +84,10 @@ namespace OpenActive.Server.NET.OpenBookingHelper
         // Summary:
         //     The intended HTTP status code of the response
         public HttpStatusCode StatusCode { get; internal set; } = HttpStatusCode.OK;
+        //
+        // Summary:
+        //     The Cache-Control header intended for the response (public, max-age=X)
+        public TimeSpan CacheControlMaxAge { get; internal set; }
 
         public override string ToString()
         {

--- a/OpenActive.Server.NET/OpenBookingHelper/Settings/BookingEngineSettings.cs
+++ b/OpenActive.Server.NET/OpenBookingHelper/Settings/BookingEngineSettings.cs
@@ -26,6 +26,16 @@ namespace OpenActive.Server.NET.OpenBookingHelper
         public OrdersRPDEFeedGenerator OrdersFeedGenerator { get; set; }
         public OrdersRPDEFeedGenerator OrderProposalsFeedGenerator { get; set; }
         public SellerStore SellerStore { get; set; }
-        public bool HasSingleSeller { get; set; }
+        public bool HasSingleSeller { get; set; } = false;
+        /// <summary>
+        /// TTL in the Cache-Control header for all RPDE pages that contain greater than zero items
+        /// See https://developer.openactive.io/publishing-data/data-feeds/scaling-feeds for CDN configuration instructions
+        /// </summary>
+        public TimeSpan RPDEPageCacheDuration { get; set; } = TimeSpan.FromHours(1);
+        /// <summary>
+        /// TTL in the Cache-Control header for all RPDE pages that contain zero items
+        /// See https://developer.openactive.io/publishing-data/data-feeds/scaling-feeds for CDN configuration instructions
+        /// </summary>
+        public TimeSpan RPDELastPageCacheDuration { get; set; } = TimeSpan.FromSeconds(8);
     }
 }


### PR DESCRIPTION
Add Cache-Control headers to open data RPDE feeds, which closes #137.

Note this PR will not break existing implementations, however existing implementations will need to upgrade their local ResponseContentHelper classes to take advantage of this feature.