### PR TITLE
feat: Env var to disable token auth

### DIFF
--- a/Examples/BookingSystem.AspNetCore/Startup.cs
+++ b/Examples/BookingSystem.AspNetCore/Startup.cs
@@ -18,6 +18,11 @@ namespace BookingSystem.AspNetCore
         {
             AppSettings = new AppSettings();
             configuration.Bind(AppSettings);
+
+            // Provide a simple way to disable token auth for some testing scenarios
+            if (System.Environment.GetEnvironmentVariable("DISABLE_TOKEN_AUTH") == "true") {
+                AppSettings.FeatureFlags.EnableTokenAuth = false;
+            }
         }
 
         public AppSettings AppSettings { get; }


### PR DESCRIPTION
A simple way to use the reference implementation without its authentication module